### PR TITLE
_blinkTiming is now a fixed array to prevent memory errors.

### DIFF
--- a/src/BlinkControl.cpp
+++ b/src/BlinkControl.cpp
@@ -51,10 +51,6 @@ BlinkControl::BlinkControl(int pin, uint8_t channel, double freq, uint8_t resolu
 }
 #endif
 
-BlinkControl::~BlinkControl() {
-  delete[] this->_blinkTiming;
-}
-
 void BlinkControl::begin() {
   this->_offOne();
   this->_timingCursor = 0;
@@ -254,8 +250,7 @@ void BlinkControl::blink(int timings[], int timingCount) {
     this->off();
   }
   
-  this->_timingCount = timingCount;
-  this->_blinkTiming = new int[this->_timingCount];
+  this->_timingCount = min(timingCount, MAX_TIMING_COUNT);
   for (int i = 0; i < this->_timingCount; i++) {
     this->_blinkTiming[i] = timings[i];
   }
@@ -339,7 +334,6 @@ void BlinkControl::fadeOut(unsigned int duration) {
 
 void BlinkControl::clearBlink() {
   this->_offOne();
-  delete[] this->_blinkTiming;
   this->_timingCount = 0;
   this->_pinOn = false;
   this->_prevState = BC_STATE_OFF;

--- a/src/BlinkControl.h
+++ b/src/BlinkControl.h
@@ -30,6 +30,7 @@
 #include <Arduino.h>
 #include <Shifty.h>
 
+#define MAX_TIMING_COUNT  16
 #define BC_STATE_OFF      0
 #define BC_STATE_ON       1
 #define BC_STATE_BLINK    2
@@ -97,7 +98,7 @@ class BlinkControl {
     int blinkTiming4[8]   = {80,80,80,80,80,80,80,440};
     int blinkTiming625[2] = {80,80};
     
-    int* _blinkTiming;
+    int _blinkTiming[MAX_TIMING_COUNT];
     int _timingCount  = 0;
     int _timingCursor = 0;
     unsigned long _lastAction = 0;


### PR DESCRIPTION
creation of _blinkTiming leaks memory and the destruction was also unchecked. Replaced it with a fixed array of size 16.